### PR TITLE
Change AMQP broker to conform to RabbitMQ best practices

### DIFF
--- a/broker/amqp.go
+++ b/broker/amqp.go
@@ -37,8 +37,6 @@ func (a *AMQP) Connect(url string) error {
 		return err
 	}
 	a.publishConn = pubConn
-    	consumeConn, err := amqp.Dial(url)
-    	a.consumeConn = consumeConn
 	ch, err := pubConn.Channel()
     	a.publishChannel = ch
 	if err != nil {
@@ -90,6 +88,8 @@ func (a *AMQP) Publish(event string, data []byte) error {
 
 // Subscribe will make this client consume for the specific event
 func (a *AMQP) Subscribe(events ...string) error {
+	consumeConn, err := amqp.Dial(url)
+    	a.consumeConn = consumeConn
 	for i := range events {
 		event := events[i]
 		subgroup := ""

--- a/broker/amqp.go
+++ b/broker/amqp.go
@@ -65,9 +65,7 @@ func (a *AMQP) Close() error {
 		return err
 	}
 	if a.consumeConn != nil {
-		if err := a.consumeConn.Close(); err != nil {
-            		return err
-        	}
+		return a.consumeConn.Close()
 	}
 	return nil
 }

--- a/broker/amqp.go
+++ b/broker/amqp.go
@@ -9,8 +9,8 @@ import (
 // AMQP is a broker for AMQP clients. Probably most useful for RabbitMQ.
 type AMQP struct {
 	publishConn *amqp.Connection
-    publishChannel *amqp.Channel
-    consumeConn *amqp.Connection
+    	publishChannel *amqp.Channel
+    	consumeConn *amqp.Connection
 
 	receiveCallback func(string, []byte)
 	consumerTags    map[string]string
@@ -37,10 +37,10 @@ func (a *AMQP) Connect(url string) error {
 		return err
 	}
 	a.publishConn = pubConn
-    consumeConn, err := amqp.Dial(url)
-    a.consumeConn = consumeConn
+    	consumeConn, err := amqp.Dial(url)
+    	a.consumeConn = consumeConn
 	ch, err := pubConn.Channel()
-    a.publishChannel = ch
+    	a.publishChannel = ch
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (a *AMQP) Close() error {
 	if err != nil {
 		return err
 	}
-    err = a.consumeConn.Close()
+    	err = a.consumeConn.Close()
 	if err != nil {
 		return err
 	}
@@ -97,8 +97,8 @@ func (a *AMQP) Subscribe(events ...string) error {
 			subgroup = a.Subgroup + ":"
 		}
 		queueName := fmt.Sprintf("%s:%s%s", a.Group, subgroup, event)
-        ch, err := a.consumeConn.Channel()
-        if err != nil {
+        	ch, err := a.consumeConn.Channel()
+        	if err != nil {
 			return err
 		}
 

--- a/broker/amqp.go
+++ b/broker/amqp.go
@@ -64,9 +64,10 @@ func (a *AMQP) Close() error {
 	if err != nil {
 		return err
 	}
-    	err = a.consumeConn.Close()
-	if err != nil {
-		return err
+	if a.consumeConn != nil {
+		if err := a.consumeConn.Close(); err != nil {
+            		return err
+        	}
 	}
 	return nil
 }


### PR DESCRIPTION
The current AMQP broker has publishers and consumers relying on one connection and channel. RabbitMQ recommends that these are separate, meaning both the publisher and consumer should have their own connection for maximum throughput. Regarding channels, RabbitMQ also recommends that you have one long-standing channel to publish messages from, as well as one channel per consumer. In this commit, I have made the necessary revisions to conform to RabbitMQ best practices.

This change, however, means that one cannot unsubscribe from events in the same way that was done earlier. I am not 100% sure about how to go about this, so I am open to suggestions on how to resolve it.